### PR TITLE
プレビュー領域以外を隠す

### DIFF
--- a/lib/ViewPage.js
+++ b/lib/ViewPage.js
@@ -1,3 +1,12 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+// ref. https://teno-hira.com/media/?p=1615
+const __dirname = (() => {
+  const __filename = fileURLToPath(import.meta.url);
+  return path.dirname(__filename);
+})();
+
 export const isViewPage = (url) => {
   const { pathname } = new URL(url);
   const newPageRegExp = new RegExp(
@@ -21,6 +30,11 @@ export class ViewPage {
   }
 
   async start() {
+    // プレビュー領域以外を隠す
+    this.page.addStyleTag({
+      path: path.join(__dirname, "./viewEditPage.css"),
+    });
+
     // monacoがロードされるまで待つ
     await this.page.waitForFunction(
       () => window.monaco?.editor?.getEditors()?.[0],

--- a/lib/viewEditPage.css
+++ b/lib/viewEditPage.css
@@ -1,0 +1,22 @@
+/* プレビュー領域以外を隠す */
+/* パンくずリスト */
+#scroll-area > div.px-4.py-4.border-b.w-full,
+/* ページタイトルヘッダー */
+#scroll-area > div.px-8.py-4 > div.flex.flex-col.x-auto,
+/* 編集フォーム */
+#scroll-area > div.px-8.py-4 > div.pb-8 > div > form {
+  display: none;
+}
+
+/* 要素を隠すと高さが確保できなくなるので調整する */
+#scroll-area > div.px-8.py-4,
+#scroll-area > div.px-8.py-4 > div.pb-8,
+#scroll-area > div.px-8.py-4 > div.pb-8 > div,
+#scroll-area > div.px-8.py-4 > div.pb-8 > div > div {
+  height: 100%;
+}
+
+/* ビューの周囲のpaddingを表示ページと同様にする */
+#scroll-area > div.px-8.py-4 {
+  padding: 0;
+}


### PR DESCRIPTION
プレビュー領域以外を隠します。

https://basemachina.slack.com/archives/C0164F05TCH/p1719225698714799?thread_ts=1719224177.876319&cid=C0164F05TCH

### スクリーンショット

![image](https://github.com/basemachina/bmview-preview/assets/118240974/aa0ca2c9-f21c-4fab-8bb5-3d4b2ce0604c)

### 未解決の課題

- CSSのセレクタが壊れやすい
- ナビゲーションが常に隠される（編集画面では非表示）

bmview-preview用の専用プレビューページをweb_clientに追加するのがよさそう。とりあえずbmview-previewだけで解決できる範囲の修正を入れます。