### PR TITLE
ビュー選択サイドバーのクリッカブルな要素をbuttonタグにする

### DIFF
--- a/lib/PreviewPage.js
+++ b/lib/PreviewPage.js
@@ -78,7 +78,7 @@ export class PreviewPage {
           const $button = document.createElement("button");
           $button.setAttribute(
             "class",
-            "p-2 text-left w-full rounded-md text-gray-500 hover:bg-gray-200 hover:text-gray-900 cursor-pointer"
+            "p-2 text-left w-full rounded-md text-gray-500 hover:bg-gray-200 hover:text-gray-900"
           );
           $button.textContent = filename;
           $button.addEventListener("click", () => {


### PR DESCRIPTION
ビュー選択サイドバーのクリッカブルな要素を`li`タグで表現していましたが、より適切な`button`タグに置き換えます。

### スクリーンショット

見た目は変わっていません。

![image](https://github.com/basemachina/bm-view-preview/assets/118240974/95482e35-f414-4b4a-ad41-c8641297e718)