### PR TITLE
package.jsonにpublishConfigを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,9 @@
   },
   "type": "module",
   "license": "BSD-3-Clause",
-  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
+  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  }
 }


### PR DESCRIPTION
scoped packageはデフォルトでprivateになるので、明示的にpublicにする必要がある。