### PR TITLE
support js config

### DIFF
--- a/bin/bm-view-preview
+++ b/bin/bm-view-preview
@@ -3,5 +3,5 @@
 import { getOptions } from "../lib/getOptions.js";
 import { run } from "../lib/run.js";
 
-const options = getOptions();
+const options = await getOptions();
 run(options);

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -1,9 +1,15 @@
 import path from "node:path";
-import { cosmiconfigSync } from "cosmiconfig";
+import { cosmiconfig } from "cosmiconfig";
 
-export const getOptions = () => {
-  const result = cosmiconfigSync("bm-view-preview", {
-    searchPlaces: ["bm-view-preview.config.json"],
+export const getOptions = async () => {
+  const result = await cosmiconfig("bm-view-preview", {
+    searchPlaces: [
+      "bm-view-preview.config.json",
+      "bm-view-preview.config.cjs",
+      "bm-view-preview.config.js",
+      "bm-view-preview.config.ts",
+      "bm-view-preview.config.mjs",
+    ],
   }).search();
   if (!result) {
     throw new Error("設定ファイルがありません");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemachina/bm-view-preview",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "ローカル環境のJSXファイルをベースマキナのビューとしてプレビュー表示するツール",
   "bin": {
     "bm-view-preview": "./bin/bm-view-preview"


### PR DESCRIPTION
`bm-view-preview.config.cjs`などの形式の設定ファイルをサポートするように変更します。