### PR TITLE
npx playwright installの手順を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 1. `package.json`を作成する
 1. `npm install --save-dev @basemachina/bm-view-preview`を実行する
 1. 設定ファイルを作成する
-1. `npm install --save-dev playwright`を実行する
-1. `npx playwright install chromium`を実行する
 
 #### 設定ファイルの作り方
 


### PR DESCRIPTION
#25 の対応で不要になったため。