### PR TITLE
replace xdg-basedir with env-paths

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -14,7 +14,7 @@ export const run = async ({ baseUrl, sourceDir }) => {
   }
 
   const browser = await chromium.launchPersistentContext(
-    path.join(appEnvPaths.cache, "bm-view-preview", "chromium_profile"),
+    path.join(appEnvPaths.cache, "chromium_profile"),
     {
       headless: false,
       viewport: null, // ウィンドウのリサイズに合わせてviewportのサイズを変える

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,9 +1,11 @@
 import process from "node:process";
 import path from "node:path";
 import { chromium } from "playwright";
-import { xdgCache } from "xdg-basedir";
+import envPaths from "env-paths";
 import { watchFile, watchDirectory } from "./watch.js";
 import { isNewViewPage, PreviewPage } from "./PreviewPage.js";
+
+const appEnvPaths = envPaths("bm-view-preview");
 
 export const run = async ({ baseUrl, sourceDir }) => {
   if (!baseUrl) {
@@ -12,7 +14,7 @@ export const run = async ({ baseUrl, sourceDir }) => {
   }
 
   const browser = await chromium.launchPersistentContext(
-    path.join(xdgCache, "bm-view-preview", "chromium_profile"),
+    path.join(appEnvPaths.cache, "bm-view-preview", "chromium_profile"),
     {
       headless: false,
       viewport: null, // ウィンドウのリサイズに合わせてviewportのサイズを変える

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemachina/bm-view-preview",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "ローカル環境のJSXファイルをベースマキナのビューとしてプレビュー表示するツール",
   "bin": {
     "bm-view-preview": "./bin/bm-view-preview"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@playwright/browser-chromium": "^1.45.1",
     "cosmiconfig": "^9.0.0",
-    "playwright": "^1.45.1",
-    "xdg-basedir": "^5.1.0"
+    "env-paths": "^3.0.0",
+    "playwright": "^1.45.1"
   },
   "type": "module",
   "license": "BSD-3-Clause",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,12 @@ importers:
       cosmiconfig:
         specifier: ^9.0.0
         version: 9.0.0
+      env-paths:
+        specifier: ^3.0.0
+        version: 3.0.0
       playwright:
         specifier: ^1.45.1
         version: 1.45.1
-      xdg-basedir:
-        specifier: ^5.1.0
-        version: 5.1.0
 
 packages:
 
@@ -72,6 +72,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -138,10 +142,6 @@ packages:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
 
-  xdg-basedir@5.1.0:
-    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
-    engines: {node: '>=12'}
-
 snapshots:
 
   '@babel/code-frame@7.24.7':
@@ -190,6 +190,8 @@ snapshots:
       parse-json: 5.2.0
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -245,5 +247,3 @@ snapshots:
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
-
-  xdg-basedir@5.1.0: {}


### PR DESCRIPTION
[xdg-basedir](https://github.com/sindresorhus/xdg-basedir)はLinux以外をサポートしていないため、[env-paths](https://github.com/sindresorhus/env-paths)に置き換えます。