### PR TITLE
ブラウザのセキュリティに関する設定を有効化する

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -18,7 +18,6 @@ export const run = async ({ baseUrl, sourceDir }) => {
     {
       headless: false,
       viewport: null, // ウィンドウのリサイズに合わせてviewportのサイズを変える
-      bypassCSP: true,
     }
   );
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -18,6 +18,7 @@ export const run = async ({ baseUrl, sourceDir }) => {
     {
       headless: false,
       viewport: null, // ウィンドウのリサイズに合わせてviewportのサイズを変える
+      chromiumSandbox: true,
     }
   );
 


### PR DESCRIPTION
- `bypassCSP`: https://playwright.dev/docs/api/class-testoptions#test-options-bypass-csp
    - 開発初期に追加した設定でしたが、現在は設定がなくても動作するので削除します
- `chromiumSandbox`: https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-chromium-sandbox
    - デフォルトで無効になっていますが、bm-view-previewの動作には支障ないようなので有効化します