### PR TITLE
ブラウザのソースファイルの選択欄にディレクトリが表示される問題を修正

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -18,7 +18,7 @@ export const watchFile = (filePath, callback) => {
   });
 };
 
-/** 呼び出しの直後とディレクトリが更新されることにファイルの一覧を引数にしてコールバック関数を呼ぶ */
+/** 呼び出しの直後とディレクトリが更新されるごとにファイルの一覧を引数にしてコールバック関数を呼ぶ */
 export const watchDirectory = async (dirPath, callback) => {
   const notify = () =>
     fs.readdir(dirPath, { withFileTypes: true }, (err, entries) => {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -21,9 +21,11 @@ export const watchFile = (filePath, callback) => {
 /** 呼び出しの直後とディレクトリが更新されることにファイルの一覧を引数にしてコールバック関数を呼ぶ */
 export const watchDirectory = async (dirPath, callback) => {
   const notify = () =>
-    fs.readdir(dirPath, (err, files) => {
+    fs.readdir(dirPath, { withFileTypes: true }, (err, entries) => {
       if (err) throw err;
-      callback(files);
+      callback(
+        entries.filter((entry) => entry.isFile()).map((entry) => entry.name)
+      );
     });
   notify();
   fs.watch(dirPath, notify);


### PR DESCRIPTION
設定ファイルの`sourceDir`で指定したディレクトリの中にディレクトリがあった場合、ブラウザのソースファイルの選択欄にそのまま表示されてしまう問題を修正します。