### PR TITLE
クエリパラメーターを変更して再読み込みしたら元のファイルを再表示する

### DIFF
--- a/lib/PreviewPage.js
+++ b/lib/PreviewPage.js
@@ -28,7 +28,7 @@ export class PreviewPage {
     this.page = page;
   }
 
-  async init() {
+  async init({ selectedViewFileName }) {
     // プレビュー領域以外を隠す
     this.page.addStyleTag({
       path: path.join(__dirname, "./previewPage.css"),
@@ -72,10 +72,13 @@ export class PreviewPage {
       },
     );
 
-    // 新規作成時のサンプルコードを上書きする
-    this.updateViewCode(
-      `export default () => "プレビューするファイルを選択してください。";`,
-    );
+    if (selectedViewFileName) {
+      this.onViewSelected(selectedViewFileName);
+    } else {
+      this.updateViewCode(
+        `export default () => "プレビューするファイルを選択してください。";`,
+      );
+    }
   }
 
   // ページ内のビューの一覧を更新する

--- a/lib/fileSystem/listFiles.js
+++ b/lib/fileSystem/listFiles.js
@@ -1,0 +1,7 @@
+import fs from "node:fs/promises";
+
+/** ディレクトリのファイルの一覧を返す */
+export const listFiles = async (dirPath) => {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+};

--- a/lib/fileSystem/watchDirectory.js
+++ b/lib/fileSystem/watchDirectory.js
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+
+/** 呼び出しの直後とディレクトリが更新されるごとにファイルの一覧を引数にしてコールバック関数を呼ぶ */
+export const watchDirectory = async (dirPath, callback) => {
+  const notify = () =>
+    fs.readdir(dirPath, { withFileTypes: true }, (err, entries) => {
+      if (err) throw err;
+      callback(
+        entries.filter((entry) => entry.isFile()).map((entry) => entry.name),
+      );
+    });
+  notify();
+  fs.watch(dirPath, notify);
+};

--- a/lib/fileSystem/watchDirectory.js
+++ b/lib/fileSystem/watchDirectory.js
@@ -1,14 +1,9 @@
 import fs from "node:fs";
+import { listFiles } from "./listFiles.js";
 
 /** 呼び出しの直後とディレクトリが更新されるごとにファイルの一覧を引数にしてコールバック関数を呼ぶ */
 export const watchDirectory = async (dirPath, callback) => {
-  const notify = () =>
-    fs.readdir(dirPath, { withFileTypes: true }, (err, entries) => {
-      if (err) throw err;
-      callback(
-        entries.filter((entry) => entry.isFile()).map((entry) => entry.name),
-      );
-    });
-  notify();
+  const notify = async () => callback(await listFiles(dirPath));
   fs.watch(dirPath, notify);
+  await listFiles(dirPath);
 };

--- a/lib/fileSystem/watchDirectory.js
+++ b/lib/fileSystem/watchDirectory.js
@@ -5,5 +5,4 @@ import { listFiles } from "./listFiles.js";
 export const watchDirectory = async (dirPath, callback) => {
   const notify = async () => callback(await listFiles(dirPath));
   fs.watch(dirPath, notify);
-  await listFiles(dirPath);
 };

--- a/lib/fileSystem/watchFile.js
+++ b/lib/fileSystem/watchFile.js
@@ -17,16 +17,3 @@ export const watchFile = (filePath, callback) => {
     setTimeout(notify, 100);
   });
 };
-
-/** 呼び出しの直後とディレクトリが更新されるごとにファイルの一覧を引数にしてコールバック関数を呼ぶ */
-export const watchDirectory = async (dirPath, callback) => {
-  const notify = () =>
-    fs.readdir(dirPath, { withFileTypes: true }, (err, entries) => {
-      if (err) throw err;
-      callback(
-        entries.filter((entry) => entry.isFile()).map((entry) => entry.name),
-      );
-    });
-  notify();
-  fs.watch(dirPath, notify);
-};

--- a/lib/run.js
+++ b/lib/run.js
@@ -4,6 +4,7 @@ import { chromium } from "playwright";
 import envPaths from "env-paths";
 import { watchFile } from "./fileSystem/watchFile.js";
 import { watchDirectory } from "./fileSystem/watchDirectory.js";
+import { listFiles } from "./fileSystem/listFiles.js";
 import { isNewViewPage, PreviewPage, getEnvironment } from "./PreviewPage.js";
 
 const appEnvPaths = envPaths("bm-view-preview");
@@ -44,6 +45,8 @@ export const run = async ({ baseUrl, sourceDir, allowedEnvironments }) => {
   // alert, confirmなどを自動で閉じないようにする
   page.on("dialog", () => {});
 
+  let lastSelectedFileName = null;
+
   // NOTE: loadイベントではrouterによるページ遷移を拾えない
   page.on("load", async () => {
     // ログインセッションが切れているとログイン画面に飛ばされるので少し待つ
@@ -66,10 +69,11 @@ export const run = async ({ baseUrl, sourceDir, allowedEnvironments }) => {
     }
 
     const previewPage = new PreviewPage(page);
-    await previewPage.init();
 
     let viewFileWatcher;
     previewPage.onViewSelected = (viewFileName) => {
+      lastSelectedFileName = viewFileName;
+
       // すでにwatcherを作っていたら停止する
       viewFileWatcher?.close();
 
@@ -79,6 +83,21 @@ export const run = async ({ baseUrl, sourceDir, allowedEnvironments }) => {
         (code) => previewPage.updateViewCode(code),
       );
     };
+
+    // ファイルを選択したことがあれば再表示する
+    // （URLバーにクエリパラメーターを追加してページを再読み込みしたとき、初期画面ではなく選択していたファイルを表示させるため）
+    const selectedViewFileName = await (async () => {
+      if (lastSelectedFileName === null) {
+        return null;
+      }
+      const files = await listFiles(sourceDir);
+      if (!files.includes(lastSelectedFileName)) {
+        return null;
+      }
+      return lastSelectedFileName;
+    })();
+
+    await previewPage.init({ selectedViewFileName });
 
     watchDirectory(sourceDir, (filenames) => {
       previewPage.updateViewList(filenames);

--- a/lib/run.js
+++ b/lib/run.js
@@ -2,7 +2,8 @@ import process from "node:process";
 import path from "node:path";
 import { chromium } from "playwright";
 import envPaths from "env-paths";
-import { watchFile, watchDirectory } from "./watch.js";
+import { watchFile } from "./fileSystem/watchFile.js";
+import { watchDirectory } from "./fileSystem/watchDirectory.js";
 import { isNewViewPage, PreviewPage, getEnvironment } from "./PreviewPage.js";
 
 const appEnvPaths = envPaths("bm-view-preview");


### PR DESCRIPTION
# 解決したい問題

ビューのコード内で[`useURLQueries`](https://docs.basemachina.com/view/function/view_use_url_queries/)を使っている場合、開発時にURLのクエリパラメーターを変更したいことがあります。

現在の実装では、URLのクエリパラメーターを変更してページを再読み込みすると、ファイルの選択状態がリセットされ、「プレビューするファイルを選択してください。」という初期表示に戻ってしまっていました。

# 実装方針

ページを再読み込みしたときに元のファイルを再表示する処理を追加します。

再表示に関するロジックは`run.js`に置いて、`PreviewPage.js`はページの操作だけを行うようにしています。

（`PreviewPage`クラスを操作する処理は`run.js`から切り出したほうがよさそうな感じになってきましたが、別PRであらためて対応しようと思っています。）