### PR TITLE
プレビューにbm-view-preview専用の画面を使う

### DIFF
--- a/lib/PreviewPage.js
+++ b/lib/PreviewPage.js
@@ -7,21 +7,26 @@ const __dirname = (() => {
   return path.dirname(__filename);
 })();
 
-export const isNewViewPage = (url) => {
+export const isBmViewPreviewPage = (url) => {
   const { pathname } = new URL(url);
-  const regexp = new RegExp("^/projects/[^/]+/environments/[^/]+/views/new$");
+  const regexp = new RegExp(
+    "^/projects/[^/]+/environments/[^/]+/views/bm-view-preview$",
+  );
   return regexp.test(pathname);
 };
 
 export const getEnvironment = (url) => {
   const { pathname } = new URL(url);
-  const regexp = new RegExp("^/projects/[^/]+/environments/([^/]+)/views/new$");
+  const regexp = new RegExp(
+    "^/projects/[^/]+/environments/([^/]+)/views/bm-view-preview$",
+  );
   const match = pathname.match(regexp);
   return match?.[1];
 };
 
 const inPageCallbackFunctionName = "__bmViewPreviewOnSelectView";
 const bmViewPreviewViewListId = "bm-view-preview-view-list";
+const setCodeEventName = "bmViewPreviewSetCode";
 
 export class PreviewPage {
   constructor(page) {
@@ -61,24 +66,6 @@ export class PreviewPage {
       );
       document.documentElement.appendChild($sidebar);
     }, bmViewPreviewViewListId);
-
-    // monacoがロードされるまで待つ
-    await this.page.waitForFunction(
-      () => window.monaco?.editor?.getEditors()?.[0],
-      null,
-      {
-        polling: 100, // 100ms
-        timeout: 0, // disable timeout
-      },
-    );
-
-    if (selectedViewFileName) {
-      this.onViewSelected(selectedViewFileName);
-    } else {
-      this.updateViewCode(
-        `export default () => "プレビューするファイルを選択してください。";`,
-      );
-    }
   }
 
   // ページ内のビューの一覧を更新する
@@ -104,11 +91,14 @@ export class PreviewPage {
     );
   }
 
-  // ページ内のmonacoエディタにコードを入力する
   async updateViewCode(code) {
-    this.page.evaluate((code) => {
-      const editor = window.monaco?.editor?.getEditors()?.[0];
-      editor?.setValue(code);
-    }, code);
+    await this.page.evaluate(
+      ({ setCodeEventName, code }) => {
+        window.dispatchEvent(
+          new CustomEvent(setCodeEventName, { detail: { code } }),
+        );
+      },
+      { setCodeEventName, code },
+    );
   }
 }

--- a/lib/PreviewPage.test.js
+++ b/lib/PreviewPage.test.js
@@ -1,23 +1,23 @@
 import { describe, expect, test } from "vitest";
-import { isNewViewPage } from "./PreviewPage";
+import { isBmViewPreviewPage } from "./PreviewPage";
 
-describe("isNewViewPage ", () => {
+describe("isBmViewPreviewPage  ", () => {
   test.each([
     {
-      url: "https://demo.basemachina.com/projects/PROJECT_ID/environments/ENVIRONMENT_ID/actions/new",
+      url: "https://demo.basemachina.com/projects/PROJECT_ID/environments/ENVIRONMENT_ID/actions/bm-view-preview",
       expected: false,
     },
     {
-      url: "https://demo.basemachina.com/projects/PROJECT_ID/environments/ENVIRONMENT_ID/views/new",
+      url: "https://demo.basemachina.com/projects/PROJECT_ID/environments/ENVIRONMENT_ID/views/bm-view-preview",
       expected: true,
     },
 
     // BaseMachina開発チームのローカル環境などでも動作させるため、ドメイン名は検証していない
     {
-      url: "https://example.com/projects/PROJECT_ID/environments/ENVIRONMENT_ID/views/new",
+      url: "https://example.com/projects/PROJECT_ID/environments/ENVIRONMENT_ID/views/bm-view-preview",
       expected: true,
     },
-  ])("isNewViewPage($url) -> $expected", ({ url, expected }) => {
-    expect(isNewViewPage(url)).toBe(expected);
+  ])("isBmViewPreviewPage ($url) -> $expected", ({ url, expected }) => {
+    expect(isBmViewPreviewPage(url)).toBe(expected);
   });
 });

--- a/lib/previewPage.css
+++ b/lib/previewPage.css
@@ -1,26 +1,3 @@
-/* プレビュー領域以外を隠す */
-/* パンくずリスト */
-#scroll-area > div.px-4.py-4.border-b.w-full,
-/* ページタイトルヘッダー */
-#scroll-area > div.px-8.py-4 > div.breadcrumbs-page-layout-header,
-/* 編集フォーム */
-#scroll-area > div.px-8.py-4 > div.pb-8 > div > form {
-  display: none;
-}
-
-/* 要素を隠すと高さが確保できなくなるので調整する */
-#scroll-area > div.px-8.py-4,
-#scroll-area > div.px-8.py-4 > div.pb-8,
-#scroll-area > div.px-8.py-4 > div.pb-8 > div,
-#scroll-area > div.px-8.py-4 > div.pb-8 > div > div {
-  height: 100%;
-}
-
-/* ビューの周囲のpaddingを表示ページと同様にする */
-#scroll-area > div.px-8.py-4 {
-  padding: 0;
-}
-
 /* ファイル選択UIを画面横に配置する */
 html {
   display: flex;

--- a/lib/run.js
+++ b/lib/run.js
@@ -5,7 +5,11 @@ import envPaths from "env-paths";
 import { watchFile } from "./fileSystem/watchFile.js";
 import { watchDirectory } from "./fileSystem/watchDirectory.js";
 import { listFiles } from "./fileSystem/listFiles.js";
-import { isNewViewPage, PreviewPage, getEnvironment } from "./PreviewPage.js";
+import {
+  isBmViewPreviewPage,
+  PreviewPage,
+  getEnvironment,
+} from "./PreviewPage.js";
 
 const appEnvPaths = envPaths("bm-view-preview");
 
@@ -15,11 +19,11 @@ export const run = async ({ baseUrl, sourceDir, allowedEnvironments }) => {
     process.exit(1);
   }
 
-  const baseViewPage = `${baseUrl}/views/new`;
+  const bmViewPreviewPage = `${baseUrl}/views/bm-view-preview`;
 
   if (
     allowedEnvironments &&
-    !allowedEnvironments.includes(getEnvironment(baseViewPage))
+    !allowedEnvironments.includes(getEnvironment(bmViewPreviewPage))
   ) {
     console.error("baseUrlに設定されたEnvironmentが許可されていない環境です");
     process.exit(1);
@@ -59,12 +63,12 @@ export const run = async ({ baseUrl, sourceDir, allowedEnvironments }) => {
       environment &&
       !allowedEnvironments.includes(environment)
     ) {
-      // 許可されていない環境の場合、baseUrlにリダイレクトする
-      await page.goto(baseViewPage);
+      // 許可されていない環境の場合、bmViewPreviewPageにリダイレクトする
+      await page.goto(bmViewPreviewPage);
       return;
     }
 
-    if (!isNewViewPage(page.url())) {
+    if (!isBmViewPreviewPage(page.url())) {
       return;
     }
 
@@ -77,10 +81,12 @@ export const run = async ({ baseUrl, sourceDir, allowedEnvironments }) => {
       // すでにwatcherを作っていたら停止する
       viewFileWatcher?.close();
 
-      // ファイルが変更されるたびにmonacoに入力する
+      // ファイルが変更されるたびにプレピューページに反映する
       viewFileWatcher = watchFile(
         path.resolve(sourceDir, viewFileName),
-        (code) => previewPage.updateViewCode(code),
+        (code) => {
+          previewPage.updateViewCode(code);
+        },
       );
     };
 
@@ -104,5 +110,5 @@ export const run = async ({ baseUrl, sourceDir, allowedEnvironments }) => {
     });
   });
 
-  await page.goto(baseViewPage);
+  await page.goto(bmViewPreviewPage);
 };


### PR DESCRIPTION
これまではプレピューにビューの新規作成画面を利用していましたが、bm-view-previewの専用の画面を利用するように変更します。

この変更によるメリットは以下の通りです。

- 新規作成画面では手入力を前提にしていたため、コードの入力から反映までに 1.5秒のdebounceを設定しています。専用の画面ではdebounceをより短くできるため、 レスポンス速度が向上します。
- 新規作成画面をbm-view-preview向けに調整するためのCSSの大半が不要になります。