### PR TITLE
watchDirectory関数の呼び出し時にファイル一覧を取得する

### DIFF
--- a/lib/fileSystem/watchDirectory.js
+++ b/lib/fileSystem/watchDirectory.js
@@ -4,5 +4,6 @@ import { listFiles } from "./listFiles.js";
 /** 呼び出しの直後とディレクトリが更新されるごとにファイルの一覧を引数にしてコールバック関数を呼ぶ */
 export const watchDirectory = async (dirPath, callback) => {
   const notify = async () => callback(await listFiles(dirPath));
+  await notify();
   fs.watch(dirPath, notify);
 };


### PR DESCRIPTION
`fs.watch`関数はディレクトリ内の更新を検知しないとコールバック関数を実行しないので、`watchDirectory()`の呼び出し時に手動で`notify()`を実行する必要がありました。

（https://github.com/basemachina/bm-view-preview/pull/41#discussion_r1919489998 では不要かと思って削除しましたが、実際には必要でした。検証時にはエディタが自動でディレクトリ内のファイルを更新したために`fs.watch`関数でコールバック関数が実行されていたようです）