### PR TITLE
ブラウザが閉じられたことを確認してからプロセスを終了する

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -42,7 +42,8 @@ export const run = async ({ baseUrl, sourceDir, allowedEnvironments }) => {
   const page = (await browser.pages())[0];
 
   // 最初のタブが閉じられたら終了する
-  page.on("close", () => {
+  page.on("close", async () => {
+    await browser.close();
     process.exit();
   });
 


### PR DESCRIPTION
Chromiumのタブが閉じられるとbm-view-previewも自動で終了するようにしていますが、Chromiumのプロセス終了を待っていませんでした。その結果、bm-view-previewの終了時にChromiumが強制終了され、次回起動時にエラーが表示されることがありました。

![image](https://github.com/user-attachments/assets/1414fae3-6469-4a65-8764-b31235efc8b1)

明示的に`browser.close()`を呼んで完了を待つように修正します。