### PR TITLE
fix: ブラウザ起動失敗時にプロファイルを自動修復して再試行する

### DIFF
--- a/bin/bm-view-preview.js
+++ b/bin/bm-view-preview.js
@@ -3,5 +3,10 @@
 import { getOptions } from "../lib/getOptions.js";
 import { run } from "../lib/run.js";
 
-const options = await getOptions();
-run(options);
+try {
+  const options = await getOptions();
+  await run(options);
+} catch (error) {
+  console.error(`エラーが発生しました: ${error?.message ?? error}`);
+  process.exit(1);
+}

--- a/lib/chromiumProfile.js
+++ b/lib/chromiumProfile.js
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// SingletonLock symlinkの参照先 "hostname-pid" をパースする。
+// hostname自体にハイフンを含むことがあるため、最後のハイフンで分割する。
+export const parseSingletonLockTarget = (target) => {
+  const match = /^(.+)-(\d+)$/.exec(target);
+  if (!match) {
+    return null;
+  }
+  return { hostname: match[1], pid: Number(match[2]) };
+};
+
+export const isProcessAlive = (pid) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERMは「存在するが操作権限がない」なので生存扱い
+    return error.code === "EPERM";
+  }
+};
+
+// プロファイルを使用中の生きているChromiumプロセスのpidを返す。使用中でなければnull。
+// 判定できないケース（lockなし・symlinkでない・パース不能・別ホストのlock・pid死亡）は
+// すべてnullとし、扱いをChromium自身に委ねる（stale lockはChromiumが自力回復できる）。
+export const getRunningChromiumPid = async (
+  profileDir,
+  { hostname = os.hostname(), isAlive = isProcessAlive } = {},
+) => {
+  let target;
+  try {
+    target = await fs.readlink(path.join(profileDir, "SingletonLock"));
+  } catch {
+    return null;
+  }
+  const parsed = parseSingletonLockTarget(target);
+  if (!parsed || parsed.hostname !== hostname) {
+    return null;
+  }
+  return isAlive(parsed.pid) ? parsed.pid : null;
+};
+
+// プロファイル破損などでChromiumが起動できなくなったとき、ログイン情報だけを
+// 引き継いだ新しいプロファイルを作り直す。元のプロファイルは丸ごと退避して残す。
+const carryOverEntries = [
+  "Local State", // Cookieの暗号鍵などを含む
+  "Default/Cookies",
+  "Default/Cookies-journal",
+  "Default/Login Data",
+  "Default/Login Data-journal",
+  "Default/Login Data For Account",
+  "Default/Login Data For Account-journal",
+  "Default/Local Storage",
+  "Default/WebStorage",
+];
+
+export const repairChromiumProfile = async (profileDir) => {
+  const backupDir = `${profileDir}.broken-${Date.now()}`;
+  await fs.rename(profileDir, backupDir);
+  await fs.mkdir(path.join(profileDir, "Default"), { recursive: true });
+
+  for (const entry of carryOverEntries) {
+    try {
+      await fs.cp(path.join(backupDir, entry), path.join(profileDir, entry), {
+        recursive: true,
+      });
+    } catch {
+      // 存在しないファイルはスキップ
+    }
+  }
+
+  return backupDir;
+};

--- a/lib/chromiumProfile.test.js
+++ b/lib/chromiumProfile.test.js
@@ -1,0 +1,157 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  getRunningChromiumPid,
+  isProcessAlive,
+  parseSingletonLockTarget,
+  repairChromiumProfile,
+} from "./chromiumProfile";
+
+describe("parseSingletonLockTarget", () => {
+  test.each([
+    { target: "myhost-12345", expected: { hostname: "myhost", pid: 12345 } },
+    // hostnameにハイフンを含む場合は最後のハイフンで分割する
+    {
+      target: "my-host.local-999",
+      expected: { hostname: "my-host.local", pid: 999 },
+    },
+    { target: "nohyphen", expected: null },
+    { target: "host-abc", expected: null },
+    { target: "", expected: null },
+  ])(
+    "parseSingletonLockTarget($target) -> $expected",
+    ({ target, expected }) => {
+      expect(parseSingletonLockTarget(target)).toEqual(expected);
+    },
+  );
+});
+
+describe("isProcessAlive", () => {
+  test("自プロセスのpidは生存扱い", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  test("存在しないpidは死亡扱い", () => {
+    // pidの上限(2^22など)を大きく超える値はESRCHになる
+    expect(isProcessAlive(2 ** 30)).toBe(false);
+  });
+});
+
+describe("getRunningChromiumPid", () => {
+  let profileDir;
+
+  beforeEach(async () => {
+    profileDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bm-view-preview-test-"),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(profileDir, { recursive: true, force: true });
+  });
+
+  const lockPath = () => path.join(profileDir, "SingletonLock");
+
+  test("SingletonLockがなければnull", async () => {
+    expect(await getRunningChromiumPid(profileDir)).toBe(null);
+  });
+
+  test("hostname一致かつpid生存ならpidを返す", async () => {
+    await fs.symlink(`${os.hostname()}-${process.pid}`, lockPath());
+    expect(await getRunningChromiumPid(profileDir)).toBe(process.pid);
+  });
+
+  test("pidが死んでいればnull（stale lockはChromiumに任せる）", async () => {
+    await fs.symlink(`${os.hostname()}-${process.pid}`, lockPath());
+    expect(
+      await getRunningChromiumPid(profileDir, { isAlive: () => false }),
+    ).toBe(null);
+  });
+
+  test("hostnameが一致しなければnull", async () => {
+    await fs.symlink(`other-host-${process.pid}`, lockPath());
+    expect(
+      await getRunningChromiumPid(profileDir, { hostname: "this-host" }),
+    ).toBe(null);
+  });
+
+  test("symlinkでなく通常ファイルならnull", async () => {
+    await fs.writeFile(lockPath(), `${os.hostname()}-${process.pid}`);
+    expect(await getRunningChromiumPid(profileDir)).toBe(null);
+  });
+
+  test("参照先がパース不能ならnull", async () => {
+    await fs.symlink("garbage", lockPath());
+    expect(await getRunningChromiumPid(profileDir)).toBe(null);
+  });
+});
+
+describe("repairChromiumProfile", () => {
+  let baseDir;
+  let profileDir;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "bm-view-preview-test-"));
+    profileDir = path.join(baseDir, "chromium_profile");
+    await fs.mkdir(path.join(profileDir, "Default", "Local Storage"), {
+      recursive: true,
+    });
+    await fs.writeFile(path.join(profileDir, "Local State"), "local state");
+    await fs.writeFile(path.join(profileDir, "Default", "Cookies"), "cookies");
+    await fs.writeFile(
+      path.join(profileDir, "Default", "Local Storage", "data"),
+      "storage",
+    );
+    // 引き継ぎ対象外
+    await fs.writeFile(path.join(profileDir, "Default", "History"), "history");
+    await fs.writeFile(path.join(profileDir, "Variations"), "variations");
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  test("元のプロファイルを退避し、ログイン関連のみ引き継ぐ", async () => {
+    const backupDir = await repairChromiumProfile(profileDir);
+
+    // 退避先に元の内容が丸ごと残っている
+    expect(backupDir).not.toBe(profileDir);
+    await expect(
+      fs.readFile(path.join(backupDir, "Default", "History"), "utf8"),
+    ).resolves.toBe("history");
+
+    // 新しいプロファイルにはログイン関連だけがある
+    await expect(
+      fs.readFile(path.join(profileDir, "Local State"), "utf8"),
+    ).resolves.toBe("local state");
+    await expect(
+      fs.readFile(path.join(profileDir, "Default", "Cookies"), "utf8"),
+    ).resolves.toBe("cookies");
+    await expect(
+      fs.readFile(
+        path.join(profileDir, "Default", "Local Storage", "data"),
+        "utf8",
+      ),
+    ).resolves.toBe("storage");
+    await expect(
+      fs.access(path.join(profileDir, "Default", "History")),
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(profileDir, "Variations")),
+    ).rejects.toThrow();
+  });
+
+  test("引き継ぎ対象が存在しなくてもエラーにならない", async () => {
+    await fs.rm(path.join(profileDir, "Default", "Cookies"));
+    await fs.rm(path.join(profileDir, "Local State"));
+
+    const backupDir = await repairChromiumProfile(profileDir);
+
+    expect(backupDir).not.toBe(profileDir);
+    await expect(
+      fs.access(path.join(profileDir, "Default")),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/lib/run.js
+++ b/lib/run.js
@@ -10,6 +10,10 @@ import {
   PreviewPage,
   getEnvironment,
 } from "./PreviewPage.js";
+import {
+  getRunningChromiumPid,
+  repairChromiumProfile,
+} from "./chromiumProfile.js";
 
 const appEnvPaths = envPaths("bm-view-preview");
 
@@ -35,9 +39,10 @@ export const run = async ({
     process.exit(1);
   }
 
-  const browser = await chromium.launchPersistentContext(
-    path.join(appEnvPaths.cache, "chromium_profile"),
-    {
+  const profileDir = path.join(appEnvPaths.cache, "chromium_profile");
+
+  const launch = () =>
+    chromium.launchPersistentContext(profileDir, {
       headless: false,
       viewport: null, // ウィンドウのリサイズに合わせてviewportのサイズを変える
       chromiumSandbox: true,
@@ -45,8 +50,31 @@ export const run = async ({
         ? { ignoreDefaultArgs: ["--disable-extensions"] }
         : {}),
       ...launchOptions,
-    },
-  );
+    });
+
+  let browser;
+  try {
+    browser = await launch();
+  } catch {
+    // 別のbm-view-preview / Chromiumが同じプロファイルで起動中の場合は修復せず案内する
+    const runningPid = await getRunningChromiumPid(profileDir);
+    if (runningPid !== null) {
+      console.error(
+        `bm-view-previewはすでに起動しています（プロセスID: ${runningPid}）。\n` +
+          "既存のbm-view-previewのウィンドウを閉じてから、再度実行してください。",
+      );
+      process.exit(1);
+    }
+
+    // プロファイルの状態が原因でChromiumが起動時にクラッシュすることがあるため、
+    // ログイン情報だけを引き継いだプロファイルに作り直して再試行する
+    const backupDir = await repairChromiumProfile(profileDir);
+    console.error(
+      "ブラウザの起動に失敗したため、プロファイルを修復して再試行します（ログイン情報は引き継がれます）。\n" +
+        `元のプロファイルは ${backupDir} に退避しました。`,
+    );
+    browser = await launch();
+  }
 
   // とりあえず最初のタブだけ監視対象にしている
   const page = (await browser.pages())[0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemachina/bm-view-preview",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "ローカル環境のJSXファイルをベースマキナのビューとしてプレビュー表示するツール",
   "bin": {
     "bm-view-preview": "./bin/bm-view-preview.js"


### PR DESCRIPTION
## 背景

利用側リポジトリで `bm-view-preview` の起動が以下のエラーで落ちる事象が発生した。

```
browserType.launchPersistentContext: Target page, context or browser has been closed
```

実機調査の結果、原因は多重起動ではなく、**使い込まれた永続プロファイル × 古いChromium（0.0.11のPlaywright 1.53 = Chromium 138）× macOS 26.3.2 の組み合わせで Chromium 本体が起動直後に SIGTRAP でクラッシュ**するものだった（macOSのクラッシュレポートで確認。空プロファイルでは正常に起動し、同じプロファイルでも 0.0.12 の新しい Chromium なら正常に起動する）。

また、launch の失敗が unhandled rejection になるため、利用者には生のスタックトレースと大量の Chromium ログしか見えず、原因も対処も分からない状態だった。

## 変更内容

- **プロファイルの自動修復** (`lib/chromiumProfile.js` 新規): ブラウザ起動に失敗したとき、ログイン情報（`Cookies` / `Login Data` / `Local Storage` / `WebStorage` / `Local State`）だけを引き継いだプロファイルに作り直して 1 回だけ再試行する。元のプロファイルは `chromium_profile.broken-<timestamp>` に丸ごと退避して残す
- **多重起動の検知**: `SingletonLock` の指す pid が生存している場合は「プロファイルを別インスタンスが使用中」なので修復せず、プロセスIDつきの案内を出して終了する（使用中のプロファイルを退避してしまう事故の防止）。stale lock（死んだ pid）は Chromium 自身が回復できるため関与しない
- **エラーハンドリング** (`bin/bm-view-preview.js`): top-level の try/catch を追加し、予期しないエラーを日本語メッセージで表示（生スタックトレースの unhandled rejection を廃止）
- version bump (0.0.13)

## 検証

- `pnpm test`（vitest 18件）
- 実際にクラッシュを起こしていた実プロファイルのコピーに修復処理を適用 → クラッシュしていた Chromium 138 で正常起動することを確認
- 修復後のプロファイルで利用側リポジトリの `pnpm views dev` が正常起動することを確認
- 起動中にもう1プロセス実行 → 修復は走らず、プロセスIDつきメッセージで終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)